### PR TITLE
chore: swap to bitnami legacy for pg-bouncer

### DIFF
--- a/values/upstream-values.yaml
+++ b/values/upstream-values.yaml
@@ -6,7 +6,7 @@ image:
   repository: zalando/postgres-operator
   tag: v1.14.0
 configConnectionPooler:
-  connection_pooler_image: "docker.io/bitnami/pgbouncer:1.24.1"
+  connection_pooler_image: "docker.io/bitnamilegacy/pgbouncer:1.24.1"
 configLogicalBackup:
   logical_backup_docker_image: "ghcr.io/zalando/postgres-operator/logical-backup:v1.14.0"
 configGeneral:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -65,7 +65,7 @@ components:
     images:
       - ghcr.io/zalando/postgres-operator:v1.14.0
       - ghcr.io/zalando/postgres-operator/logical-backup:v1.14.0
-      - docker.io/bitnami/pgbouncer:1.24.1
+      - docker.io/bitnamilegacy/pgbouncer:1.24.1
       # Docker image that provides PostgreSQL and Patroni bundled together for PostgreSQL HA
       - ghcr.io/zalando/spilo-17:4.0-p2
       # Container image that provides the postgres-exporter sidecar to create a metrics endpoint


### PR DESCRIPTION
## Description

- Update the pgbouncer image to pull from Bitnamilegacy. 
- This will eventually have to be replaced with an actual alternative.

## Related Issue

Fixes #
<!-- or -->
Relates to #
https://github.com/orgs/uds-packages/projects/2/views/20?pane=issue&itemId=132958916&issue=uds-packages%7Cmaintenance%7C79
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
