### PR TITLE
fix: renovate manager for spilo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,11 +11,11 @@
     {
       "matchDatasources": ["docker"],
       "matchPackagePatterns": ["^quay\\.io/rfcurated/"],
-      "allowedVersions": "!/-arm64|-aarch64/"
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?-.*fips.*rfcurated$"
     },
     {
-      "matchPackageNames": ["quay.io/rfcurated/zalando/spilo-17"],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-p(?<patch>\\d+)(-jammy-fips-rfcurated)?$"
+      "matchPackageNames": ["quay.io/rfcurated/prometheuscommunity/postgres-exporter"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?-jammy-scratch-bnt-fips-rfcurated$"
     },
     {
       "matchPackageNames": ["ghcr.io/zalando/spilo-17"],

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": ["quay.io/rfcurated/zalando/spilo-17"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-p(?<patch>\\d+)-jammy-fips-rfcurated$"
+    },
+    {
       "groupName": "Postgres Support Dependencies",
       "labels": [
         "support-deps"

--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,17 @@
   ],
   "packageRules": [
     {
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^quay\\.io/rfcurated/"],
+      "allowedVersions": "!/-arm64|-aarch64/"
+    },
+    {
       "matchPackageNames": ["quay.io/rfcurated/zalando/spilo-17"],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-p(?<patch>\\d+)-jammy-fips-rfcurated$"
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-p(?<patch>\\d+)(-jammy-fips-rfcurated)?$"
+    },
+    {
+      "matchPackageNames": ["ghcr.io/zalando/spilo-17"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-p(?<patch>\\d+)$"
     },
     {
       "groupName": "Postgres Support Dependencies",


### PR DESCRIPTION
## Description

Renovate not catching update 
- `spilo-17:4.0-p2-jammy-fips-rfcurated` -> `spilo-17:4.0-p3-jammy-fips-rfcurated`
- `spilo-17:4.0-p2` ->  `spilo-17:4.0-p3`

[Test in this repo](https://github.com/uds-packages/repo-to-test-renovate/pull/29) compared to [this repos current package deps updates](https://github.com/defenseunicorns/uds-package-postgres-operator/pull/132).


Test renovate manager updated in with this [renovate.json](https://github.com/uds-packages/repo-to-test-renovate/blob/account-for-all-flavors/renovate.json).

## Related Issue

https://github.com/defenseunicorns/uds-package-postgres-operator/issues/140

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)
