### PR TITLE
fix: renovate rule for rfcurate spilo-17

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,10 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?-jammy-scratch-bnt-fips-rfcurated$"
     },
     {
+      "matchPackageNames": ["quay.io/rfcurated/zalando/spilo-17"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-p(?<patch>\\d+)-jammy-fips-rfcurated$"
+    },
+    {
       "matchPackageNames": ["ghcr.io/zalando/spilo-17"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-p(?<patch>\\d+)$"
     },


### PR DESCRIPTION
## Description

quay.io/rfcurated/zalando/spilo-17:4.0-p2-jammy-fips-rfcurated -> quay.io/rfcurated/zalando/spilo-17:4.0-p3-jammy-fips-rfcurated

Implementation tested in `repo-to-test-renovate` [found here.](https://github.com/uds-packages/repo-to-test-renovate/pull/29/files) and renovate.json [merged found here.](https://github.com/uds-packages/repo-to-test-renovate/pull/35/files)

## Related Issue
Closes https://github.com/defenseunicorns/uds-package-postgres-operator/issues/140

Relates to #

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
