### PR TITLE
chore: update stale swf references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in this Defense Unicorns UDS Package!
 
-This package is part of Defense Unicorns' UDS Software Factory and follows the contributing guidelines outlined in that repositories' [CONTRIBUTING.md](https://github.com/defenseunicorns/uds-software-factory/blob/main/CONTRIBUTING.md) file.
+This package is part of Defense Unicorns' Unicorn Delivery Service and follows the contributing guidelines outlined in [uds-common's CONTRIBUTING.md](https://github.com/defenseunicorns/uds-common/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/uds-packages/postgres-operator/release.yaml)](https://github.com/uds-packages/postgres-operator/actions/workflows/release.yaml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/uds-packages/postgres-operator/badge)](https://api.securityscorecards.dev/projects/github.com/uds-packages/postgres-operator)
 
-This package is designed for use as part of a [UDS Software Factory](https://github.com/defenseunicorns/uds-software-factory) bundle deployed on [UDS Core](https://github.com/defenseunicorns/uds-core).
+This package is designed for use as part of a [UDS Bundle](https://docs.defenseunicorns.com/core/concepts/configuration--packaging/bundles/) bundle deployed on [UDS Core](https://github.com/defenseunicorns/uds-core).
 
 > The Postgres Operator is a software tool that automates the deployment and management of PostgreSQL databases on Kubernetes, simplifying the process of setting up and maintaining highly available and scalable PostgreSQL clusters.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-As [UDS Software Factory](https://github.com/defenseunicorns/uds-software-factory) has not yet reached v1.0.0, only the current latest minor release is supported.
+Only the current latest minor release is supported.
 
 ## Reporting a Vulnerability
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,10 @@
 # Configuration
 
-Postgres Operator is configured through the upstream [Zalando Postgres Operator chart](https://github.com/zalando/postgres-operator/tree/master/charts/postgres-operator) as well as a UDS configuration chart. It implements a database for many [applications within UDS Software Factory](https://github.com/defenseunicorns/uds-software-factory/blob/main/docs/database.md#uds-postgres-operator-package) when one is not available in your cloud provider.
+Postgres Operator is configured through the upstream [Zalando Postgres Operator chart](https://github.com/zalando/postgres-operator/tree/master/charts/postgres-operator) as well as a UDS configuration chart. It implements a database for many [applications within a UDS Bundle](https://docs.defenseunicorns.com/core/concepts/configuration--packaging/bundles/) when one is not available in your cloud provider.
 
 ## Networking
 
-Network policies are controlled via the `uds-postgres-config` chart in accordance with the [common patterns for networking within UDS Software Factory](https://github.com/defenseunicorns/uds-software-factory/blob/main/docs/networking.md).  Because Postgres does not interact with external resources like object storage it only implements `custom` networking for the `postgres-operator` namespace:
+Network policies are controlled via the `uds-postgres-config` chart and follow [similar networking patterns as the Reference Package](https://github.com/uds-packages/reference-package/blob/main/chart/templates/uds-package.yaml#L48). Because Postgres does not interact with external resources like object storage it only implements `custom` networking for the `postgres-operator` namespace:
 
 - `additionalNetworkAllow`: sets custom network policies for the `postgres-operator` namespace (as a break glass in case you deploy your own postgres cluster custom resources - see below)
 
@@ -20,7 +20,7 @@ Postgres Operator is configured through [`acid.zalan.do/v1` `Postgresql` custom 
 - `postgresql.databases`: The database names to create and the users they map to (i.e. `gitlabdb: gitlab.gitlab`)
 - `postgresql.extensions`: A map of database names to lists of extensions to enable for that database (i.e. `mydb: ["postgis", "hstore"]`)
 - `postgresql.version`: The version of Postgres to run (i.e. `14`)
-- `postgresql.ingress`: A list of ingress entries to create for this cluster (follows the [custom networking definition](https://github.com/defenseunicorns/uds-software-factory/blob/main/docs/networking.md) except for `direction` which is always `Ingress` and `selector` which is always `cluster-name: pg-cluster`)
+- `postgresql.ingress`: A list of ingress entries to create for this cluster (follows the [custom networking definition](https://github.com/uds-packages/reference-package/blob/main/chart/templates/uds-package.yaml#L48) except for `direction` which is always `Ingress` and `selector` which is always `cluster-name: pg-cluster`)
 - `postgresql.resources`: A Kubernetes Pod resource specification to define requests and limits
 - `postgresql.additionalVolumes`: A list of additional volumes to map into the Postgres container if needed (see below)
 - `postgresql.tls`: TLS configuration for the Postgres cluster to use (follows the [`tls` section of the Zalando Postgres CR](https://github.com/zalando/postgres-operator/blob/master/docs/reference/cluster_manifest.md#custom-tls-certificates))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ Postgres Operator is configured through the upstream [Zalando Postgres Operator 
 
 ## Networking
 
-Network policies are controlled via the `uds-postgres-config` chart and follow [similar networking patterns as the Reference Package](https://github.com/uds-packages/reference-package/blob/main/chart/templates/uds-package.yaml#L48). Because Postgres does not interact with external resources like object storage it only implements `custom` networking for the `postgres-operator` namespace:
+Network policies are controlled via the `uds-postgres-config` chart and follow [similar networking patterns as the Reference Package](https://github.com/uds-packages/reference-package/blob/main/chart/templates/uds-package.yaml). Because Postgres does not interact with external resources like object storage it only implements `custom` networking for the `postgres-operator` namespace:
 
 - `additionalNetworkAllow`: sets custom network policies for the `postgres-operator` namespace (as a break glass in case you deploy your own postgres cluster custom resources - see below)
 
@@ -20,7 +20,7 @@ Postgres Operator is configured through [`acid.zalan.do/v1` `Postgresql` custom 
 - `postgresql.databases`: The database names to create and the users they map to (i.e. `gitlabdb: gitlab.gitlab`)
 - `postgresql.extensions`: A map of database names to lists of extensions to enable for that database (i.e. `mydb: ["postgis", "hstore"]`)
 - `postgresql.version`: The version of Postgres to run (i.e. `14`)
-- `postgresql.ingress`: A list of ingress entries to create for this cluster (follows the [custom networking definition](https://github.com/uds-packages/reference-package/blob/main/chart/templates/uds-package.yaml#L48) except for `direction` which is always `Ingress` and `selector` which is always `cluster-name: pg-cluster`)
+- `postgresql.ingress`: A list of ingress entries to create for this cluster (follows the [custom networking definition](https://github.com/uds-packages/reference-package/blob/main/chart/templates/uds-package.yaml) except for `direction` which is always `Ingress` and `selector` which is always `cluster-name: pg-cluster`)
 - `postgresql.resources`: A Kubernetes Pod resource specification to define requests and limits
 - `postgresql.additionalVolumes`: A list of additional volumes to map into the Postgres container if needed (see below)
 - `postgresql.tls`: TLS configuration for the Postgres cluster to use (follows the [`tls` section of the Zalando Postgres CR](https://github.com/zalando/postgres-operator/blob/master/docs/reference/cluster_manifest.md#custom-tls-certificates))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,10 @@ Postgres Operator is configured through [`acid.zalan.do/v1` `Postgresql` custom 
       value: <value>
 ```
 
+## Secrets Creation
+
+The operator creates credentials secrets in the namespace defined by the `{namespace}.{username}` prefix in `postgresql.users`. See the [Reference Package configuration](https://github.com/uds-packages/reference-package/blob/main/docs/configuration.md#secrets-creation) for an example of how to consume these secrets within an application chart.
+
 ## Postgres HugePages
 
 Postgres Operator can also support HugePages by setting the following keys appropriately for your environment.  You can learn more about HugePages in Kubernetes in their [Manage HugePages documentation](https://kubernetes.io/docs/tasks/manage-hugepages/scheduling-hugepages/#api) and learn more about these fields in the [`Postgresql` custom resource reference documentation](https://github.com/zalando/postgres-operator/blob/master/docs/reference/cluster_manifest.md#cluster-manifest-reference).


### PR DESCRIPTION
## Description

SWF has been archived for awhile. Updated stale references from SWF.

## Related Issue

Relates to # https://linear.app/defense-unicorns/issue/FDRY-76/uds-docs-fix-doc-references-to-old-swf-repo-common-patterns

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
