### PR TITLE
fix: conditional for disabled postgres

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -25,9 +25,12 @@ components:
       onDeploy:
         before:
           # this shims postgres operator versions v0.11.1-uds.1 and below to the new config chart namespace layout
-          - cmd: ./zarf tools kubectl annotate --overwrite postgresql -n postgres pg-cluster meta.helm.sh/release-namespace=postgres-operator || true
-          - cmd: ./zarf tools kubectl annotate --overwrite service -n postgres pg-cluster-headless meta.helm.sh/release-namespace=postgres-operator || true
-          - cmd: ./zarf tools kubectl annotate --overwrite package -n postgres postgres meta.helm.sh/release-namespace=postgres-operator || true
+          - cmd: |
+              if ./zarf tools kubectl get namespace postgres 2>/dev/null; then
+                ./zarf tools kubectl annotate --overwrite postgresql -n postgres pg-cluster meta.helm.sh/release-namespace=postgres-operator || true
+                ./zarf tools kubectl annotate --overwrite service -n postgres pg-cluster-headless meta.helm.sh/release-namespace=postgres-operator || true
+                ./zarf tools kubectl annotate --overwrite package -n postgres postgres meta.helm.sh/release-namespace=postgres-operator || true
+              fi
         after:
           - description: Validate Postgres Operator Package
             maxTotalSeconds: 300
@@ -40,8 +43,10 @@ components:
           - description: Validate Postgres Package
             maxTotalSeconds: 300
             cmd: |
-              if ./zarf tools kubectl get packages.uds.dev postgres -n postgres; then
-                 ./zarf tools wait-for packages.uds.dev postgres -n postgres '{.status.phase}'=Ready
+              if ./zarf tools kubectl get namespace postgres 2>/dev/null; then
+                if ./zarf tools kubectl get packages.uds.dev postgres -n postgres; then
+                  ./zarf tools wait-for packages.uds.dev postgres -n postgres '{.status.phase}'=Ready
+                fi
               fi
           - description: Postgres Operator to be Healthy
             maxTotalSeconds: 90
@@ -54,6 +59,8 @@ components:
           - description: Wait for Postgres cluster to be Running if postgresql.enabled is true
             maxTotalSeconds: 300
             cmd: |
-              if ./zarf tools kubectl get postgresql pg-cluster -n postgres; then
-                 ./zarf tools wait-for postgresql pg-cluster -n postgres '{.status.PostgresClusterStatus}'=Running
+              if ./zarf tools kubectl get namespace postgres 2>/dev/null; then
+                if ./zarf tools kubectl get postgresql pg-cluster -n postgres; then
+                  ./zarf tools wait-for postgresql pg-cluster -n postgres '{.status.PostgresClusterStatus}'=Running
+                fi
               fi


### PR DESCRIPTION
## Description

- Added conditionals to suppress "Error from server (NotFound): packages.uds.dev "postgres" not found" error message when setting `postgresql.enabled: false`
- Tested locally with `postgresql.enabled: false` and confirmed no error mesages.
- Tested locally with `postgres.enabled: true` to verify existing functionality.
## Related Issue

Fixes #126 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed

## Screenshot
Screenshot showing the shim still working on upgrade when postgres is `enabled`
<img width="1109" height="214" alt="CleanShot 2026-05-20 at 10 59 21" src="https://github.com/user-attachments/assets/74d3628d-d89b-4acd-8227-e0887c320ee2" />
