### PR TITLE
fix: add working zalando-style pgbouncer image

### DIFF
--- a/releaser.yaml
+++ b/releaser.yaml
@@ -10,4 +10,4 @@ flavors:
     version: 1.15.1-uds.17
   - name: unicorn
     # renovate-uds: datasource=docker depName=cgr.dev/defenseunicorns.com/postgres-operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 1.15.1-uds.33
+    version: 1.15.1-uds.34

--- a/values/unicorn-values.yaml
+++ b/values/unicorn-values.yaml
@@ -6,7 +6,7 @@ image:
   repository: defenseunicorns.com/postgres-operator
   tag: 1.15.1
 configConnectionPooler:
-  connection_pooler_image: "cgr.dev/defenseunicorns.com/pgbouncer:v1.25.2"
+  connection_pooler_image: "cgr.dev/defenseunicorns.com/zalando-pgbouncer:2.0.1"
 configLogicalBackup:
   logical_backup_docker_image: "cgr.dev/defenseunicorns.com/postgres-operator-logical-backup-fips:1.15.1"
 configGeneral:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -93,7 +93,7 @@ components:
     images:
       - cgr.dev/defenseunicorns.com/postgres-operator:1.15.1
       - cgr.dev/defenseunicorns.com/postgres-operator-logical-backup-fips:1.15.1
-      - cgr.dev/defenseunicorns.com/pgbouncer:v1.25.2
+      - cgr.dev/defenseunicorns.com/zalando-pgbouncer:2.0.1
       # Docker image that provides PostgreSQL and Patroni bundled together for PostgreSQL HA
       - cgr.dev/defenseunicorns.com/spilo-17:4.1.2
       # Container image that provides the postgres-exporter sidecar to create a metrics endpoint


### PR DESCRIPTION
## Description

This replaces the current pgbouncer image with one that is compatible with the Zalando postgres-operator chart.

The current image fails to start when connection pooling is enabled.

Tested by setting `enableConnectionPooler: true` in `postgres-minimal.yaml`

<img width="940" height="144" alt="Screenshot 2026-08-12 at 2 25 06 PM" src="https://github.com/user-attachments/assets/d542c104-5a61-44e8-ade2-95bb24366bcb" />


## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/postgres-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
